### PR TITLE
Provide a MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md LICENSE


### PR DESCRIPTION
This is used to include the README.md and LICENSE files in the sdist
tarball.
