### PR TITLE
Don't set access_key for swift keys, fixes issue #8

### DIFF
--- a/radosgw/user.py
+++ b/radosgw/user.py
@@ -93,7 +93,7 @@ class UserInfo(object):
             else:
                 key_dict = key.__dict__
             swiftkey = Key(key_dict['user'],
-                           key_dict['access_key'], key_dict['secret_key'],
+                           None, key_dict['secret_key'],
                            'swift')
             self.swift_keys.append(swiftkey)
         # caps


### PR DESCRIPTION
Listing all users (get_users) fails on users that have swift keys because there is no access_key.  Just setting it to None in the Key class seems to work for me and seems logical.  

Problem encountered on Ceph Nautilus (14.2) but is applicable to Ceph versions at least as far back as 10.2 as noted in the open issue.  I suspect it applies to all Ceph versions.  Swift clients don't use an access_key even if some old version of Ceph did set it in the user info.     